### PR TITLE
Use servicePort in Ingress template

### DIFF
--- a/kreate/kube/templates/kubernetes/Ingress.yaml
+++ b/kreate/kube/templates/kubernetes/Ingress.yaml
@@ -40,7 +40,7 @@ spec:
               service:
                 name: {{ my.field.service }}
                 port:
-                  number: {{ my.field.containerPort }}
+                  number: {{ my.field.servicePort }}
 {% if "tls_certificate_secret" in my.field %}
   tls:
   - hosts:


### PR DESCRIPTION
Hi Mark,

I've made a small change to the Ingress template. The servicePort should be used in stead of the containerPort. We haven't discovered this issue yet because 99% of the applications are using the default 8080 port for both the service and the container. Now that we have applications with different ports, it is becoming a problem.

If you need more info, please let me know!

Kind regards,
Wesley